### PR TITLE
add support for HRV recording

### DIFF
--- a/src/ble/hrs/heart-rate-measurement.js
+++ b/src/ble/hrs/heart-rate-measurement.js
@@ -4,6 +4,7 @@
 //
 
 function HeartRateMeasurement(args = {}) {
+    const rrIntervalResolution = 1024;
 
     function decode(dataview) {
         const flags = dataview.getUint8(0, true);
@@ -34,7 +35,9 @@ function HeartRateMeasurement(args = {}) {
         if(rrIntervalPresent) {
             rrInterval = [];
             while(i <= dataview.byteLength - 2) {
-                rrInterval.push(dataview.getUint16(i, true));
+                rrInterval.push(
+                    dataview.getUint16(i, true) / rrIntervalResolution
+                );
                 i += 2;
             }
         }
@@ -49,6 +52,7 @@ function HeartRateMeasurement(args = {}) {
     }
 
     return Object.freeze({
+        rrIntervalResolution,
         decode,
     });
 }

--- a/src/ble/reactive-connectable.js
+++ b/src/ble/reactive-connectable.js
@@ -87,6 +87,10 @@ function ReactiveConnectable(args = {}) {
 
         if('heartRate' in data && models.sources.isSource('heartRate', identifier)) {
             xf.dispatch(`heartRate`, data.heartRate);
+
+            if('rrInterval' in data) {
+                xf.dispatch(`rrInterval`, data.rrInterval);
+            }
         }
 
         if('currentSaturatedHemoglobin' in data) {

--- a/src/db.js
+++ b/src/db.js
@@ -11,6 +11,7 @@ let db = {
     // Data Screen
     power: models.power.default,
     heartRate: models.heartRate.default,
+    rrInterval: [],
     cadence: models.cadence.default,
     speed: models.speed.default,
     sources: models.sources.default,
@@ -111,6 +112,10 @@ xf.reg(models.heartRate.prop, (heartRate, db) => {
     db.heartRateAvg = models.heartRateAvg.setState(heartRate);
     db.heartRateLapCount = models.heartRateLap.count;
     db.heartRateAvgCount = models.heartRateAvg.count;
+});
+
+xf.reg('rrInterval', (rrInterval, db) => {
+    db.rrInterval = rrInterval;
 });
 
 xf.reg(models.power.prop, (power, db) => {

--- a/src/fit/common.js
+++ b/src/fit/common.js
@@ -152,10 +152,12 @@ function FitNumber() {
     }
 
     function apply(scale, offset, value) {
+        if(value % 0xFF === 0) return value;
         return ((value ?? 0) * (scale ?? 1)) + ((offset ?? 0) * (scale ?? 1));
     }
 
     function remove(scale, offset, value) {
+        if(value % 0xFF === 0) return value;
         return ((value ?? 0) - ((offset ?? 0) * (scale ?? 1))) / (scale ?? 1);
     }
 

--- a/src/fit/data-record.js
+++ b/src/fit/data-record.js
@@ -55,7 +55,6 @@ function DataRecord(args = {}) {
             } else if(size > base_type_size) {
                 // array
                 for(let j = 0, k = 0; j < size; j+=base_type_size, k+=1) {
-                    console.log(value[k]);
                     type.number.encode(_field, value[k], view, acc.i+j, endian);
                 }
             } else if(type.timestamp.isTimestamp(_field.type)) {

--- a/src/fit/data-record.js
+++ b/src/fit/data-record.js
@@ -46,12 +46,23 @@ function DataRecord(args = {}) {
         return definition.fields.reduce(function(acc, field) {
             const _field = profiles.numberToField(definition.name, field.number);
             const value  = data.fields[_field.name];
+            const size = field.size;
+            const base_type_size = profiles.baseTypeToSize(field.base_type);
 
             if(type.string.isString(field.base_type)) {
+                // string
                 type.string.encode(field, value, view, acc.i, endian);
+            } else if(size > base_type_size) {
+                // array
+                for(let j = 0, k = 0; j < size; j+=base_type_size, k+=1) {
+                    console.log(value[k]);
+                    type.number.encode(_field, value[k], view, acc.i+j, endian);
+                }
             } else if(type.timestamp.isTimestamp(_field.type)) {
+                // timestamp
                 type.timestamp.encode(field, value, view, acc.i, endian);
             } else {
+                // number
                 type.number.encode(_field, value, view, acc.i, endian);
             }
 
@@ -96,14 +107,26 @@ function DataRecord(args = {}) {
                 const _field = profiles.numberToField(
                     definition.name, field.number
                 );
+                const size = field.size;
+                const base_type_size = profiles.baseTypeToSize(field.base_type);
 
                 let value;
 
                 if(type.string.isString(field.base_type)) {
+                    // string
                     value = type.string.decode(field, view, acc.i, endian);
+                } else if(size > base_type_size) {
+                    // array
+                    value = [];
+                    for(let j = 0; j < size; j+=base_type_size) {
+                        const v = type.number.decode(_field, view, acc.i+j, endian);
+                        value.push(v);
+                    }
                 } else if(type.timestamp.isTimestamp(_field.type)) {
+                    // timestamp
                     value = type.timestamp.decode(field, view, acc.i, endian);
                 } else {
+                    // number
                     value = type.number.decode(_field, view, acc.i, endian);
                 }
 

--- a/src/fit/definition-record.js
+++ b/src/fit/definition-record.js
@@ -1,4 +1,4 @@
-import { nth, } from '../functions.js';
+import { nth, isArray, } from '../functions.js';
 
 import {
     HeaderType, RecordType,
@@ -163,7 +163,8 @@ function DefinitionRecord(args = {}) {
         };
     }
 
-    // ['message_name', ['field_name'], Int]
+    // ['message_name', ['field_name'], Int] |
+    // ['message_name', [['field_name', Int]], Int]
     // ->
     // {
     //     type: RecordType
@@ -176,15 +177,17 @@ function DefinitionRecord(args = {}) {
     // }
     function toFITjs(productMessageDefinition = ['', []]) {
         const messageName    = nth(0, productMessageDefinition);
-        const fieldNames     = nth(1, productMessageDefinition);
+        const fields         = nth(1, productMessageDefinition);
+        // const fieldNames     = fields;
         const local_number   = nth(2, productMessageDefinition);
-        const numberOfFields = fieldNames.length;
+        const numberOfFields = fields.length;
         const length         = fixedContentLength + (numberOfFields * fieldLength);
 
-        return fieldNames.reduce(function(acc, fieldName) {
-            const number    = profiles.fieldNameToNumber(messageName, fieldName);
-            const size      = profiles.fieldNameToSize(fieldName);
-            const base_type = profiles.fieldNameToBaseType(fieldName);
+        return fields.reduce(function(acc, field) {
+            const name      = isArray(field) ? field[0] : field;
+            const number    = profiles.fieldNameToNumber(messageName, name);
+            const size      = isArray(field) ? field[1] : profiles.fieldNameToSize(name);
+            const base_type = profiles.fieldNameToBaseType(name);
 
             acc.data_record_length += size;
             acc.fields.push({number, size, base_type});

--- a/src/fit/local-activity.js
+++ b/src/fit/local-activity.js
@@ -224,10 +224,15 @@ function LocalActivity(args = {}) {
 
             // definition record
             definitions.record,
+            // definition hrv
+            definitions.hrv,
             // data record messages
-            ...records.map((record) => dataRecord.toFITjs(
-                definitions.record, record
-            )),
+            ...records.map((record) =>
+                dataRecord.toFITjs(
+                    record.time === undefined ? definitions.record : definitions.hrv,
+                    record
+                )
+            ),
 
             // definition events
             definitions.event,

--- a/src/fit/profiles/product-message-definitions.js
+++ b/src/fit/profiles/product-message-definitions.js
@@ -38,6 +38,9 @@ const productMessageDefinitions = [
         'saturated_hemoglobin_percent',
         'core_temperature',
     ], 3],
+    ['hrv', [
+        ['time', 10],
+    ], 4],
     ['lap', [
         'timestamp',
         'start_time',
@@ -46,7 +49,7 @@ const productMessageDefinitions = [
         'message_index',
         'event',
         'event_type',
-    ], 4],
+    ], 5],
     ['session', [
         'timestamp',
         'start_time',
@@ -67,7 +70,7 @@ const productMessageDefinitions = [
         'max_power',
         'first_lap_index',
         'num_laps',
-    ], 5],
+    ], 6],
     ['activity', [
         'timestamp',
         'total_timer_time',
@@ -76,10 +79,10 @@ const productMessageDefinitions = [
         'event',
         'event_type',
         // 'local_timestamp',
-    ], 6],
+    ], 7],
     ['course', [
         'name',
-    ], 7],
+    ], 8],
     // ['field_description', [
     //     'developer_data_index',
     //     'field_definition_number',

--- a/src/fit/profiles/profiles.js
+++ b/src/fit/profiles/profiles.js
@@ -71,6 +71,10 @@ function Profiles(args = {}) {
         return fields[name].base_type;
     }
 
+    function baseTypeToSize(base_type) {
+        return BaseTypeDefinitions[base_type].size;
+    }
+
     return Object.freeze({
         BaseType,
         BaseTypeDefinitions,
@@ -86,6 +90,7 @@ function Profiles(args = {}) {
         fieldNameToNumber,
         fieldNameToSize,
         fieldNameToBaseType,
+        baseTypeToSize,
     });
 }
 

--- a/src/watch.js
+++ b/src/watch.js
@@ -389,6 +389,13 @@ xf.reg('watch:started',   (x, db) => {
 xf.reg('watch:paused',  (x, db) => db.watchStatus = 'paused');
 xf.reg('watch:stopped', (x, db) => db.watchStatus = 'stopped');
 
+function pad(xs = [], length = 0, value = 0) {
+    for(let i = xs.length-1; i < length; i += 1) {
+        xs.push(value);
+    }
+    return xs;
+}
+
 xf.reg('watch:elapsed', (x, db) => {
     if(equals(db.watchStatus, TimerStatus.stopped)) {
         db.elapsed   = x;
@@ -419,7 +426,12 @@ xf.reg('watch:elapsed', (x, db) => {
         device_index:                 0,
     };
 
+
     db.records.push(record);
+    if(!empty(db.rrInterval)) {
+        db.records.push({time: pad(db.rrInterval, 5, 0xFFFF)});
+    }
+
     db.lap.push(record);
 
     if(equals(db.elapsed % 60, 0)) {

--- a/test/ble/heart-rate-measurement.test.js
+++ b/test/ble/heart-rate-measurement.test.js
@@ -1,0 +1,134 @@
+import { uuids } from '../../src/ble/web-ble.js';
+import { heartRateMeasurement } from '../../src/ble/hrs/heart-rate-measurement.js';
+
+global.console = {
+    log: jest.fn(),
+    error: console.error,
+    warn: console.warn,
+};
+
+describe('HeartRateMeasurement', () => {
+
+    describe('HeartRate Field', () => {
+        test('Uint8', () => {
+            const data = new DataView(new Uint8Array([0, 81]).buffer);
+            const expected = {
+                sensorContactSupported: false,
+                sensorContactStatus: false,
+                heartRate: 81,
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+        test('Uint16', () => {
+            const data = new DataView(new Uint8Array([0b00000001, 44, 1]).buffer);
+            const expected = {
+                sensorContactSupported: false,
+                sensorContactStatus: false,
+                heartRate: 300,
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+    });
+    describe('RRInterval Field', () => {
+        const resolution = heartRateMeasurement.rrIntervalResolution;
+
+        test('1 value', () => {
+            const data = new DataView(new Uint8Array([0b00010000, 67, 114, 3]).buffer);
+            const expected = {
+                sensorContactSupported: false,
+                sensorContactStatus: false,
+                heartRate: 67,
+                rrInterval: [882 / resolution]
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+
+        test('2 values', () => {
+            const data = new DataView(new Uint8Array([0b00010000, 68, 114, 3, 138, 3]).buffer);
+            const expected = {
+                sensorContactSupported: false,
+                sensorContactStatus: false,
+                heartRate: 68,
+                rrInterval: [882 / resolution, 906 / resolution]
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+
+        test('3 values', () => {
+            const data = new DataView(new Uint8Array([0b00010000, 103, 114, 3, 138, 3, 149, 4]).buffer);
+            const expected = {
+                sensorContactSupported: false,
+                sensorContactStatus: false,
+                heartRate: 103,
+                rrInterval: [882 / resolution, 906 / resolution, 1173 / resolution]
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+
+        test('and energy expenditure field present', () => {
+            const data = new DataView(new Uint8Array([0b00011000, 67, 208, 7, 114, 3]).buffer);
+            const expected = {
+                sensorContactSupported: false,
+                sensorContactStatus: false,
+                heartRate: 67,
+                energyExpenditure: 2000,
+                rrInterval: [882 / resolution]
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+    });
+    describe('EnergyExpenditure Field', () => {
+        test('energy expenditure', () => {
+            const data = new DataView(new Uint8Array([0b00001000, 67, 208, 7]).buffer);
+            const expected = {
+                sensorContactSupported: false,
+                sensorContactStatus: false,
+                heartRate: 67,
+                energyExpenditure: 2000,
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+
+        test('and Uint16 Heart Rate', () => {
+            const data = new DataView(new Uint8Array([0b00001001, 44, 1, 208, 7]).buffer);
+            const expected = {
+                sensorContactSupported: false,
+                sensorContactStatus: false,
+                heartRate: 300,
+                energyExpenditure: 2000,
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+    });
+    describe('SensorContact Flag', () => {
+        test('supported, no contact', () => {
+            const data = new DataView(new Uint8Array([0b00000100, 67]).buffer);
+            const expected = {
+                sensorContactSupported: true,
+                sensorContactStatus: false,
+                heartRate: 67,
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+
+        test('supported, contact', () => {
+            const data = new DataView(new Uint8Array([0b00000110, 67]).buffer);
+            const expected = {
+                sensorContactSupported: true,
+                sensorContactStatus: true,
+                heartRate: 67,
+            };
+            const res = heartRateMeasurement.decode(data);
+            expect(res).toEqual(expected);
+        });
+    });
+});

--- a/test/fit/hrv-data.js
+++ b/test/fit/hrv-data.js
@@ -79,7 +79,12 @@ const laps = [
     },
 ];
 
-const appData = {records, laps};
+const events = [
+    {timestamp: 1669140869000, event: 0, type: 'start', event_group: 0},
+    {timestamp: 1669140872000, event: 0, type: 'stop', event_group: 0},
+];
+
+const appData = {records, laps, events};
 // END App Data
 
 
@@ -97,7 +102,7 @@ function FITjs(args = {}) {
             headerSize: 14,
             protocolVersion: '2.0',
             profileVersion: '21.40',
-            dataSize: 466, // 489,
+            dataSize: 482, // 489,
             dataType: '.FIT',
             crc: headerCRC,
         },
@@ -297,6 +302,48 @@ function FITjs(args = {}) {
                 total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
                 saturated_hemoglobin_percent: 0, // uint16, scale 10, %
                 core_temperature: 0,             // uint16, scale 100, C
+            }
+        },
+        // defintion event
+        {
+            type: 'definition',
+            name: 'event',
+            architecture: 0,
+            local_number: 2,
+            length: 18,
+            data_record_length: 8,
+            fields: [
+                {number: 253, size: 4, base_type: 'uint32'}, // timestamp
+                {number:   0, size: 1, base_type: 'enum'},   // event
+                {number:   1, size: 1, base_type: 'enum'},   // event_type
+                {number:   4, size: 1, base_type: 'uint8'},  // event_group
+            ],
+            dev_fields: [],
+        },
+        // data event
+        {
+            type: 'data',
+            name: 'event',
+            local_number: 2,
+            length: 8,
+            fields: {
+                timestamp: 1669140869000, //
+                event: 0,                 // timer event
+                event_type: 0,            // event_type
+                event_group: 0,           //
+            }
+        },
+        // data event
+        {
+            type: 'data',
+            name: 'event',
+            local_number: 2,
+            length: 8,
+            fields: {
+                timestamp: 1669140872000, //
+                event: 0,                 // timer event
+                event_type: 1,            // event_type
+                event_group: 0,           //
             }
         },
         // definition lap

--- a/test/fit/hrv-data.js
+++ b/test/fit/hrv-data.js
@@ -1,0 +1,688 @@
+// App Data Input
+
+// Records
+const records = [
+    {
+        timestamp: 1669140869000,  // 1038075269, 133, 197, 223, 61,
+        position_lat: -128450465,  // sint32, semicircles, 95, 0, 88, 248,
+        position_long: 1978610201, // sint32, semicircles,  25, 50, 239, 117,
+        altitude: 87,              // uint16, scale 5, offset 500, m, 2935, 119, 11,
+        heart_rate: 90,            // uint8, bpm, 90
+        cadence: 70,               // uint8, rpm, 70
+        distance: 7.66,            // uint32, scale 100, m, 766, 254, 2, 0, 0,
+        speed: 6.717,              // uint16, scale 1000, m/s, 6717, 61, 26,
+        power: 160,                // uint16, w, 160, 0,
+        grade: 0,                  // sint16, scale 100, %, 0, 0,
+        device_index: 0,           // uint8, 0
+        total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
+        saturated_hemoglobin_percent: 0, // uint16, scale 10, %
+        core_temperature: 0,             // uint16, scale 100, C
+    },
+    {
+        time: [882, 906, 0xFFFF, 0xFFFF, 0xFFFF],
+    },
+    {
+        timestamp: 1669140870000,  // 1038075270, 134, 197, 223, 61,
+        position_lat: -128449747,  // sint32, semicircles, 45, 3, 88, 248,
+        position_long: 1978610154, // sint32, semicircles, 234, 49, 239, 117,
+        altitude: 87,              // uint16, scale 5, offset 500, m, 2935, 119, 11,
+        heart_rate: 91,            // uint8, bpm,
+        cadence: 71,               // uint8, rpm
+        distance: 14.36,           // uint32, scale 100, m, 156, 5, 0, 0,
+        speed: 6.781,              // uint16, scale 1000, m/s, 6781, 125, 26,
+        power: 161,                // uint16, w, 161, 0,
+        grade: 0,                  // sint16, scale 100, %, 0, 0,
+        device_index: 0,           // uint8, 0
+        total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
+        saturated_hemoglobin_percent: 0, // uint16, scale 10, %
+        core_temperature: 0,             // uint16, scale 100, C
+    },
+    {
+        timestamp: 1669140871000,  // 1038075271, 135, 197, 223, 61,
+        position_lat: -128449037,  // sint32, semicircles, 243, 5, 88, 248,
+        position_long: 1978609898, // sint32, semicircles, 234, 48, 239, 117,
+        altitude: 87,              // uint16, scale 5, offset 500, m, 2935, 119, 11,
+        heart_rate: 92,            // uint8, bpm
+        cadence: 72,               // uint8, rpm
+        distance:	21.34,           // uint32, scale 100, m, 86, 8, 0, 0,
+        speed: 7.08,               // uint16, scale 1000, m/s, 7080, 168, 27,
+        power: 162,                // uint16, w, 162, 0,
+        grade: 0,                  // sint16, scale 100, %, 0, 0,
+        device_index: 0,           // uint8, 0
+        total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
+        saturated_hemoglobin_percent: 0, // uint16, scale 10, %
+        core_temperature: 0,             // uint16, scale 100, C
+    },
+    {
+        timestamp: 1669140872000,  // 1038075272, 136, 197, 223, 61,
+        position_lat: -128448324,  // sint32, semicircles, 188, 8, 88, 248,
+        position_long: 1978609588, // sint32, semicircles, 180, 47, 239, 117,
+        altitude: 87,              // uint16, scale 5, offset 500, m, 2935, 119, 11,
+        heart_rate: 93,            // uint8, bpm
+        cadence: 73,               // uint8, rpm
+        distance:	28.56,           // uint32, scale 100, m, 40, 11, 0, 0,
+        speed: 7.498,              // uint16, scale 1000, m/s, 7498, 74, 29,
+        power: 163,                // uint16, w, 163, 0,
+        grade: 0,                  // sint16, scale 100, %, 0, 0,
+        device_index: 0,           // uint8, 0
+        total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
+        saturated_hemoglobin_percent: 0, // uint16, scale 10, %
+        core_temperature: 0,             // uint16, scale 100, C
+    },
+];
+
+// Laps
+const laps = [
+    {
+        start_time: 1669140869000, // start time
+        timestamp: 1669140872000,  // end time
+    },
+];
+
+const appData = {records, laps};
+// END App Data
+
+
+
+// Expected FITjs
+function FITjs(args = {}) {
+    const headerCRC = args.crc ? 40815 : 0;
+    const fileCRC   = args.crc ? 14083 : undefined;
+
+    return [
+        // file header
+        {
+            type: 'header',
+            length: 14,
+            headerSize: 14,
+            protocolVersion: '2.0',
+            profileVersion: '21.40',
+            dataSize: 466, // 489,
+            dataType: '.FIT',
+            crc: headerCRC,
+        },
+        // definition file_id
+        {
+            type: 'definition',
+            name: 'file_id',
+            architecture: 0,
+            local_number: 0,
+            length: 24,
+            data_record_length: 16,
+            fields: [
+                {number: 4, size: 4, base_type: 'uint32'},
+                {number: 1, size: 2, base_type: 'uint16'},
+                {number: 2, size: 2, base_type: 'uint16'},
+                {number: 3, size: 4, base_type: 'uint32z'},
+                {number: 5, size: 2, base_type: 'uint16'},
+                {number: 0, size: 1, base_type: 'enum'},
+            ],
+            dev_fields: [],
+        },
+        // data file_id
+        {
+            type: 'data',
+            name: 'file_id',
+            local_number: 0,
+            length: 16,
+            fields: {
+                time_created:  1669140872000,
+                manufacturer:  1,
+                product:       3570,
+                serial_number: 3313379353,
+                number:        0,
+                type:          4,
+            },
+            // dev_fields: [],
+        },
+        // definition file_creator
+        {
+            type: 'definition',
+            name: 'file_creator',
+            architecture: 0,
+            local_number: 1,
+            length: 9,
+            data_record_length: 3,
+            fields: [
+                {number: 0, size: 2, base_type: 'uint16'}, // software_version
+            ],
+            dev_fields: [],
+        },
+        // data file_creator
+        {
+            type: 'data',
+            name: 'file_creator',
+            local_number: 1,
+            length: 3,
+            fields: {
+                software_version: 29,
+            },
+        },
+        // definition record
+        {
+            type: 'definition',
+            name: 'record',
+            architecture: 0,
+            local_number: 3,
+            length: 48,
+            data_record_length: 34,
+            fields: [
+                {number: 253, size: 4, base_type: 'uint32'}, // timestamp
+                {number:   0, size: 4, base_type: 'sint32'}, // position_lat
+                {number:   1, size: 4, base_type: 'sint32'}, // position_long
+                {number:   2, size: 2, base_type: 'uint16'}, // altitude
+                {number:   3, size: 1, base_type: 'uint8'},  // heart_rate
+                {number:   4, size: 1, base_type: 'uint8'},  // cadence
+                {number:   5, size: 4, base_type: 'uint32'}, // distance
+                {number:   6, size: 2, base_type: 'uint16'}, // speed
+                {number:   7, size: 2, base_type: 'uint16'}, // power
+                {number:   9, size: 2, base_type: 'sint16'}, // grade
+                {number:  62, size: 1, base_type: 'uint8'},  // device_index
+                {number:  54, size: 2, base_type: 'uint16'}, // total_hemoglobin_conc
+                {number:  57, size: 2, base_type: 'uint16'}, // saturated_hemoglobin_percent
+                {number:  139, size: 2, base_type: 'uint16'}, // core_temperature
+            ],
+            dev_fields: [],
+        },
+        // definition hrv
+        {
+            type: 'definition',
+            name: 'hrv',
+            architecture: 0,
+            local_number: 4,
+            length: 9,
+            data_record_length: 11,
+            fields: [
+                {number: 0, size: 10, base_type: 'uint16'}, // time
+            ],
+            dev_fields: [],
+        },
+        // data record 0
+        {
+            type: 'data',
+            name: 'record',
+            local_number: 3,
+            length: 34,
+            fields: {
+                timestamp: 1669140869000,        //
+                position_lat: -128450465,        // sint32, semicircles
+                position_long: 1978610201,       // sint32, semicircles
+                altitude: 87,                    // uint16, scale 5, offset 500, m
+                heart_rate: 90,                  // uint8, bpm
+                cadence: 70,                     // uint8, rpm
+                distance: 7.66,                  // uint32, scale 100, m
+                speed: 6.717,                    // uint16, scale 1000, m/s
+                power: 160,                      // uint16, w
+                grade: 0,                        // sint16, scale 100, %
+                device_index: 0,                 // uint8, 0
+                total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
+                saturated_hemoglobin_percent: 0, // uint16, scale 10, %
+                core_temperature: 0,             // uint16, scale 100, C
+            }
+        },
+        // data hrv 0
+        {
+            type: 'data',
+            name: 'hrv',
+            local_number: 4,
+            length: 11,
+            fields: {
+                time: [882, 906, 0xFFFF, 0xFFFF, 0xFFFF], // time array
+            }
+        },
+        // data record 1
+        {
+            type: 'data',
+            name: 'record',
+            local_number: 3,
+            length: 34,
+            fields: {
+                timestamp: 1669140870000,  //
+                position_lat: -128449747,  // sint32, semicircles
+                position_long: 1978610154, // sint32, semicircles
+                altitude: 87,              // uint16, scale 5, offset 500, m
+                heart_rate: 91,            // uint8, bpm
+                cadence: 71,               // uint8, rpm
+                distance: 14.36,           // uint32, scale 100, m
+                speed: 6.781,              // uint16, scale 1000, m/s
+                power: 161,                // uint16, w
+                grade: 0,                  // sint16, scale 100, %
+                device_index: 0,           // uint8, 0
+                total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
+                saturated_hemoglobin_percent: 0, // uint16, scale 10, %
+                core_temperature: 0,             // uint16, scale 100, C
+            }
+        },
+        // data record 2
+        {
+            type: 'data',
+            name: 'record',
+            local_number: 3,
+            length: 34,
+            fields: {
+                timestamp: 1669140871000,  //
+                position_lat: -128449037,  // sint32, semicircles
+                position_long: 1978609898, // sint32, semicircles
+                altitude: 87,              // uint16, scale 5, offset 500, m
+                heart_rate: 92,            // uint8, bpm
+                cadence: 72,               // uint8, rpm
+                distance:	21.34,           // uint32, scale 100, m
+                speed: 7.08,               // uint16, scale 1000, m/s
+                power: 162,                // uint16, w
+                grade: 0,                  // sint16, scale 100, %
+                device_index: 0,           // uint8, 0
+                total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
+                saturated_hemoglobin_percent: 0, // uint16, scale 10, %
+                core_temperature: 0,             // uint16, scale 100, C
+            }
+        },
+        // data record 3
+        {
+            type: 'data',
+            name: 'record',
+            local_number: 3,
+            length: 34,
+            fields: {
+                timestamp: 1669140872000,  //
+                position_lat: -128448324,  // sint32, semicircles
+                position_long: 1978609588, // sint32, semicircles
+                altitude: 87,              // uint16, scale 5, offset 500, m
+                heart_rate: 93,            // uint8, bpm
+                cadence: 73,               // uint8, rpm
+                distance:	28.56,           // uint32, scale 100, m
+                speed: 7.498,              // uint16, scale 1000, m/s
+                power: 163,                // uint16, w
+                grade: 0,                  // sint16, scale 100, %
+                device_index: 0,           // uint8, 0
+                total_hemoglobin_conc: 0,        // uint16, scale 100, g/dL
+                saturated_hemoglobin_percent: 0, // uint16, scale 10, %
+                core_temperature: 0,             // uint16, scale 100, C
+            }
+        },
+        // definition lap
+        {
+            type: 'definition',
+            name: 'lap',
+            architecture: 0,
+            local_number: 5,
+            length: 27,
+            data_record_length: 21,
+            fields: [
+                {number: 253, size: 4, base_type: 'uint32'}, // timestamp
+                {number: 2,   size: 4, base_type: 'uint32'}, // start_time
+                {number: 7,   size: 4, base_type: 'uint32'}, // total_elapsed_time
+                {number: 8,   size: 4, base_type: 'uint32'}, // total_timer_time
+                {number: 254, size: 2, base_type: 'uint16'}, // message_index
+                {number: 0,   size: 1, base_type: 'enum'},   // event
+                {number: 1,   size: 1, base_type: 'enum'},   // event_type
+            ],
+            dev_fields: [],
+        },
+        // data lap
+        {
+            type: 'data',
+            name: 'lap',
+            local_number: 5,
+            length: 21,
+            fields: {
+                timestamp:  1669140872000,
+                start_time: 1669140869000,
+                total_elapsed_time: 3,
+                total_timer_time: 3,
+                message_index: 0,
+                event: 9,
+                event_type: 1,
+            },
+        },
+        // definition session
+        {
+            type: 'definition',
+            architecture: 0,
+            name: 'session',
+            local_number: 6,
+            length: 63,
+            data_record_length: 43,
+            fields: [
+                {number: 253, size: 4, base_type: 'uint32'}, // timestamp
+                {number: 2,   size: 4, base_type: 'uint32'}, // start_time
+                {number: 7,   size: 4, base_type: 'uint32'}, // total_elapsed_time
+                {number: 8,   size: 4, base_type: 'uint32'}, // total_timer_time
+                {number: 254, size: 2, base_type: 'uint16'}, // message_index
+                {number: 5,   size: 1, base_type: 'enum'},   // sport
+                {number: 6,   size: 1, base_type: 'enum'},   // sub_sport
+                {number: 9,   size: 4, base_type: 'uint32'}, // total_distance
+                {number: 11,  size: 2, base_type: 'uint16'}, // total_calories
+                {number: 14,  size: 2, base_type: 'uint16'}, // avg_speed
+                {number: 15,  size: 2, base_type: 'uint16'}, // max_speed
+                {number: 16,  size: 1, base_type: 'uint8'},  // avg_heart_rate
+                {number: 17,  size: 1, base_type: 'uint8'},  // max_heart_rate
+                {number: 18,  size: 1, base_type: 'uint8'},  // avg_cadence
+                {number: 19,  size: 1, base_type: 'uint8'},  // max_cadence
+                {number: 20,  size: 2, base_type: 'uint16'}, // avg_power
+                {number: 21,  size: 2, base_type: 'uint16'}, // max_power
+                {number: 25,  size: 2, base_type: 'uint16'}, // first_lap_index
+                {number: 26,  size: 2, base_type: 'uint16'}, // num_laps
+            ],
+            dev_fields: [],
+        },
+        // data session
+        {
+            type: 'data',
+            name: 'session',
+            local_number: 6,
+            length: 43,
+            fields: {
+                timestamp:  1669140872000,
+                start_time: 1669140869000,
+                total_elapsed_time: 3,
+                total_timer_time: 3,
+                message_index: 0,
+                sport: 2,
+                sub_sport: 58,
+                total_distance: 28.56,
+                total_calories: 0, // 0.4845
+                avg_speed: 7.019,
+                max_speed: 7.498,
+                avg_heart_rate: 91, // 91.5
+                max_heart_rate: 93,
+                avg_cadence: 71, // 71.5
+                max_cadence: 73,
+                avg_power: 161, // 161.5
+                max_power: 163,
+                first_lap_index: 0,
+                num_laps: 1,
+            }
+        },
+        // definition activity
+        {
+            type: 'definition',
+            architecture: 0,
+            name: 'activity',
+            local_number: 7,
+            length: 24,
+            data_record_length: 14,
+            fields: [
+                {number: 253, size: 4, base_type: 'uint32'}, // timestamp
+                {number: 0,   size: 4, base_type: 'uint32'}, // total_timer_time
+                {number: 1,   size: 2, base_type: 'uint16'}, // num_sessions
+                {number: 2,   size: 1, base_type: 'enum'},   // type
+                {number: 3,   size: 1, base_type: 'enum'},   // event
+                {number: 4,   size: 1, base_type: 'enum'},   // event_type
+                // {number: 5,   size: 4, base_type: 'uint32'}, // local_timestamp
+            ],
+            dev_fields: [],
+        },
+        // data activity
+        {
+            type: 'data',
+            name: 'activity',
+            local_number: 7,
+            length: 14,
+            fields: {
+                timestamp: 1669140872000,
+                total_timer_time: 3,
+                num_sessions: 1,
+                type: 0,
+                event: 26,
+                event_type: 1,
+                // local_timestamp: 1669140872000,
+            }
+        },
+        // crc
+        {
+            type: 'crc',
+            length: 2,
+            crc: fileCRC,
+        }
+    ];
+};
+// END expected FITjs
+
+
+
+// Expected FIT binary
+const fitBinary = [
+    // header
+    [
+        14,           // header length
+        32,           // profile version
+        92,8,         // protocol version
+        127,1,0,0,    // data size (without header and crc)
+        46,70,73,84,  // data type (ASCII for ".FIT")
+        111, 159,     // header crc
+    ],
+    // definition file_id
+    [
+        0b01000000,  // header, 64, 0b01000000
+        0,           // reserved
+        0,           // architecture
+        0, 0,        // global number
+        5,           // number of fields
+        4, 4, 134,   // time_created
+        1, 2, 132,   // manufacturer
+        2, 2, 132,   // product
+        5, 2, 132,   // number
+        0, 1, 0,     // type
+    ],
+    // data file_id
+    [
+        0b00000000,        // header, 0, 0b00000000
+        136, 197, 223, 61, // time_created
+        255, 0,            // manufacturer
+        0, 0,              // product
+        0, 0,              // number
+        4,                 // type
+    ],
+    // definition record
+    [
+        0b01000011,  // header, 69, 0b01000101
+        0,           // reserved
+        0,           // architecture
+        20, 0,       // global number
+        11,          // number of fields
+        253, 4, 134, // timestamp
+          0, 4, 133, // position_lat
+          1, 4, 133, // position_long
+          2, 2, 132, // altitude 935
+          3, 1,   2, // heart_rate
+          4, 1,   2, // cadence
+          5, 4, 134, // distance 10000
+          6, 2, 132, // speed 6000
+          7, 2, 132, // power
+          9, 2, 131, // grade 140
+         62, 1,   2, // device_index
+    ],
+    // data record
+    [
+        0b0000011,         // header
+        133, 197, 223, 61, // timestamp
+        95, 0, 88, 248,    // position_lat
+        25, 50, 239, 117,  // position_long
+        119, 11,           // altitude 2935
+        90,                // heart_rate
+        70,                // cadence
+        254, 2, 0, 0,      // distance
+        61, 26,            // speed
+        160, 0,            // power
+        0, 0,              // grade
+        0,                 // device_index
+    ],
+    // definition hrv
+    [
+        0b01000011,  // header, 69, 0b01000101
+        0,           // reserved
+        0,           // architecture
+        20, 0,       // global number
+        1,           // number of fields
+        0, 10, 132,  // time
+    ],
+    // data hrv
+    [
+        0b0000011,   // header
+        141, 3,      // time 0
+        138, 3,      // time 1
+        255, 255,    // time 2
+        255, 255,    // time 3
+        255, 255,    // time 4
+    ],
+    [
+        0b0000011,         // header
+        134, 197, 223, 61, // timestamp
+        45, 3, 88, 248,    // position_lat
+        234, 49, 239, 117, // position_long
+        119, 11,           // altitude 2935
+        91,                // heart_rate
+        71,                // cadence
+        156, 5, 0, 0,      // distance
+        125, 26,           // speed
+        161, 0,            // power
+        0, 0,              // grade
+        0,                 // device_index
+    ],
+    [
+        0b0000011,         // header
+        135, 197, 223, 61, // timestamp
+        243, 5, 88, 248,   // position_lat
+        234, 48, 239, 117, // position_long
+        119, 11,           // altitude 2935
+        92,                // heart_rate
+        72,                // cadence
+        86, 8, 0, 0,       // distance
+        168, 27,           // speed
+        162, 0,            // power
+        0, 0,              // grade
+        0,                 // device_index
+    ],
+    [
+        0b0000011,         // header
+        136, 197, 223, 61, // timestamp
+        188, 8, 88, 248,   // position_lat
+        180, 47, 239, 117, // position_long
+        119, 11,           // altitude 2935
+        93,                // heart_rate
+        73,                // cadence
+        40, 11, 0, 0,      // distance
+        74, 29,            // speed
+        163, 0,            // power
+        0, 0,              // grade
+        0,                 // device_index
+    ],
+    // definition lap
+    [
+        0b01000100,  // header, 68, 0b01000100
+        0,           // reserved
+        0,           // architecture
+        19, 0,       // global number
+        7,           // number of fields
+        253, 4, 134, // timestamp
+          2, 4, 134, // start_time
+          7, 4, 134, // total_elapsed_time
+          8, 4, 134, // total_timer_time
+        254, 2, 132, // message_index
+          0, 1,   0, // event
+          1, 1,   0, // event_type
+    ],
+    // data lap
+    [
+        0b00000100,        // header, 68, 0b00001000
+        136, 197, 223, 61, // timestamp
+        133, 197, 223, 61, // start_time
+        184, 11, 0, 0,     // total_elapsed_time
+        184, 11, 0, 0,     // total_timer_time
+        0, 0,              // message_index
+        9,                 // event
+        1,                 // event_type
+    ],
+
+    // definition session
+    [
+        0b01000101,  // header, 69, 0b01000101
+        0,           // reserved
+        0,           // architecture
+        18, 0,       // global number
+        19,          // number of fields
+        253, 4, 134, // timestamp
+          2, 4, 134, // start_time
+          7, 4, 134, // total_elapsed_time
+          8, 4, 134, // total_timer_time
+        254, 2, 132, // message_index
+          5, 1,   0, // sport
+          6, 1,   0, // sub_sport
+          9, 4, 134, // total_distance
+         11, 2, 132, // total_calories
+         14, 2, 132, // avg_speed
+         15, 2, 132, // max_speed
+         16, 1,   2, // avg_heart_rate
+         17, 1,   2, // max_heart_rate
+         18, 1,   2, // avg_cadence
+         19, 1,   2, // max_cadence
+         20, 2, 132, // avg_power
+         21, 2, 132, // max_power
+         25, 2, 132, // first_lap_index
+         26, 2, 132, // num_laps
+    ],
+    // data session
+    [
+        0b00000101,        // header, 5, 0b00000101
+        136, 197, 223, 61, // timestamp
+        133, 197, 223, 61, // start_time
+        184, 11, 0, 0,     // total_elapsed_time
+        184, 11, 0, 0,     // total_timer_time
+        0, 0,              // message_index
+        2,                 // sport
+        58,                // sub_sport
+        40, 11, 0, 0,      // total_distance
+        0, 0,              // total_calories
+        107, 27,           // avg_speed
+        74, 29,            // max_speed
+        91,                // avg_heart_rate
+        93,                // max_heart_rate
+        71,                // avg_cadence
+        73,                // max_cadence
+        161, 0,            // avg_power
+        163, 0,            // max_power
+        0, 0,              // first_lap_index
+        1, 0,              // num_laps
+    ],
+    // definition activity
+    [
+        0b01000110,  // header, 70, 0b01000110
+        0,           // reserved
+        0,           // architecture
+        34, 0,       // global number
+        6,           // number of fields
+        253, 4, 134, // timestamp
+          0, 4, 134, // total_timer_time
+          1, 2, 132, // num sessions
+          2, 1,   0, // type
+          3, 1,   0, // event
+          4, 1,   0, // event_type
+          // 5, 4, 134, // local_timestamp
+    ],
+    // data activity
+    [
+        0b00000110,        // header, 6, 0b00000110
+        136, 197, 223, 61, // timestamp
+        184,  11,   0,  0, // total_timer_time
+        1, 0,              // num sessions
+        0,                 // type
+        26,                // event
+        1,                 // stop
+        // 136, 197, 223, 61, // local_timestamp
+    ],
+    // crc, needs to be computed last evetytime when encoding to binary
+    [
+        3,
+        55,
+    ],
+];
+
+const flatFitBinary = fitBinary.flat();
+// END Expected FIT binary
+
+export {
+    appData,
+    FITjs,
+    fitBinary,
+    flatFitBinary,
+};

--- a/test/fit/hrv.test.js
+++ b/test/fit/hrv.test.js
@@ -1,0 +1,143 @@
+import { dataviewToArray } from '../../src/functions.js';
+import { fit } from '../../src/fit/fit.js';
+import { appData, FITjs, fitBinary, flatFitBinary, } from './hrv-data.js';
+
+describe('AppData', () => {
+
+    test('DefinitionRecord.toFITjs', () => {
+        const res = fit.definitionRecord.toFITjs(
+            ['file_id', [
+                'time_created',
+                'manufacturer',
+                'product',
+                'serial_number',
+                'number',
+                'type',
+            ], 0],
+        );
+
+        expect(res).toEqual({
+            type: 'definition',
+            name: 'file_id',
+            architecture: 0,
+            local_number: 0,
+            length: 24,
+            data_record_length: 16,
+            fields: [
+                {number: 4, size: 4, base_type: 'uint32'},
+                {number: 1, size: 2, base_type: 'uint16'},
+                {number: 2, size: 2, base_type: 'uint16'},
+                {number: 3, size: 4, base_type: 'uint32z'},
+                {number: 5, size: 2, base_type: 'uint16'},
+                {number: 0, size: 1, base_type: 'enum'},
+            ],
+            dev_fields: [],
+        });
+    });
+
+    test('DefinitionRecord.toFITjs Array', () => {
+        const res = fit.definitionRecord.toFITjs(
+            ['hrv', [['time', 10],], 4],
+        );
+
+        expect(res).toEqual({
+            type: 'definition',
+            name: 'hrv',
+            architecture: 0,
+            local_number: 4,
+            length: 9,
+            data_record_length: 11,
+            fields: [
+                {number: 0, size: 10, base_type: 'uint16'}, // time
+            ],
+            dev_fields: [],
+        });
+    });
+
+    test('DataRecord.encode Array', () => {
+        const view = new DataView(new ArrayBuffer(11));
+        // const definition = fit.definitionRecord.toFITjs(['hrv', [['time', 10],], 4]);
+        const definition = {
+            type: 'definition',
+            name: 'hrv',
+            architecture: 0,
+            local_number: 4,
+            length: 9,
+            data_record_length: 11,
+            fields: [
+                {number: 0, size: 10, base_type: 'uint16'}, // time
+            ],
+            dev_fields: [],
+        };
+        const data = {time: [882, 906, 0xFFFF, 0xFFFF, 0xFFFF],};
+        const array = [];
+        const expected = {
+            type: 'data',
+            name: 'hrv',
+            local_number: 4,
+            length: 11,
+            fields: {time: [882, 906, 0xFFFF, 0xFFFF, 0xFFFF],}
+        };
+
+        const encoded = fit.dataRecord.encode(definition, data, view, 0);
+        const decoded = fit.dataRecord.decode(definition, view, 0);
+        console.log(new Uint8Array(encoded.buffer));
+
+        expect(decoded).toEqual(expected);
+    });
+
+    test.skip('toFITjs', () => {
+        const res = fit.localActivity.toFITjs({
+            records: appData.records,
+            laps: appData.laps,
+        });
+
+        expect(res).toEqual(FITjs({crc: false}));
+    });
+
+    /*
+    test('encode', () => {
+        // res: Dataview
+        const res = fit.localActivity.encode({
+            records: appData.records,
+            laps: appData.laps,
+        });
+        // resArray: [Int]
+        const resArray = dataviewToArray(res);
+
+        expect(resArray).toEqual(flatFitBinary);
+
+        // check CRC
+        var headerCRC     = fit.CRC.calculateCRC(
+            new DataView(new Uint8Array(fitBinary[0]).buffer), 0, 11);
+        var fileCRC       = fit.CRC.calculateCRC(
+            new DataView(new Uint8Array(flatFitBinary).buffer),
+            0,
+            (flatFitBinary.length - 1) - fit.CRC.size,
+        );
+        var headerCRCArray = fit.CRC.toArray(headerCRC);
+        var fileCRCArray   = fit.CRC.toArray(fileCRC);
+
+        console.log(`header crc: ${headerCRC} `, headerCRCArray);
+        console.log(`file crc: ${fileCRC} `, fileCRCArray);
+
+        var resHeaderCRCArray = fit.CRC.getHeaderCRC(res).array;
+
+        var resFileCRCArray = fit.CRC.getFileCRC(res).array;
+
+        expect(resHeaderCRCArray).toEqual(headerCRCArray);
+
+        expect(resFileCRCArray).toEqual(fileCRCArray);
+        // check CRC
+    });
+
+    test('decode', () => {
+        const array = new Uint8Array(fitBinary.flat());
+        const view = new DataView(array.buffer);
+
+        const res = fit.FITjs.decode(view);
+
+        expect(res).toEqual(FITjs({crc: true}));
+    });
+    */
+});

--- a/test/fit/hrv.test.js
+++ b/test/fit/hrv.test.js
@@ -56,7 +56,6 @@ describe('AppData', () => {
 
     test('DataRecord.encode Array', () => {
         const view = new DataView(new ArrayBuffer(11));
-        // const definition = fit.definitionRecord.toFITjs(['hrv', [['time', 10],], 4]);
         const definition = {
             type: 'definition',
             name: 'hrv',
@@ -69,27 +68,29 @@ describe('AppData', () => {
             ],
             dev_fields: [],
         };
-        const data = {time: [882, 906, 0xFFFF, 0xFFFF, 0xFFFF],};
-        const array = [];
+        const data = {time: [0.882, 0.906, 0xFFFF, 0xFFFF, 0xFFFF],};
+        const arrayT = [4, 114,3, 138,3, 255,255, 255,255, 255,255]; // true
+        const arrayF = [4, 3,114, 3,138, 255,255, 255,255, 255,255]; // false
         const expected = {
             type: 'data',
             name: 'hrv',
             local_number: 4,
             length: 11,
-            fields: {time: [882, 906, 0xFFFF, 0xFFFF, 0xFFFF],}
+            fields: {time: [0.882, 0.906, 0xFFFF, 0xFFFF, 0xFFFF],}
         };
 
         const encoded = fit.dataRecord.encode(definition, data, view, 0);
         const decoded = fit.dataRecord.decode(definition, view, 0);
-        console.log(new Uint8Array(encoded.buffer));
 
+        expect(dataviewToArray(encoded)).toEqual(arrayT);
         expect(decoded).toEqual(expected);
     });
 
-    test.skip('toFITjs', () => {
+    test('toFITjs', () => {
         const res = fit.localActivity.toFITjs({
             records: appData.records,
             laps: appData.laps,
+            events: appData.events,
         });
 
         expect(res).toEqual(FITjs({crc: false}));


### PR DESCRIPTION
- add support for encoding and decoding array types in the fit parser
- add hrv message in the product message definitions
- add test cases that cover array types and hrv message
- fix some minor bugs with the fit parser

- add support for full decoding of the Heart Rate Measurement characteristic
- add test cases for decoding Heart Rate Measurement Data

- transmit `rrInterval` from `reactive-connectable` if present in HR data
- add support for recording RR Intervals in `db` as the `rrInterval` field
- add `rrInterval` to records

The RR Intervals array seems to be of fixed length 5 and needs to be padded to the end with the invalid value 0xFFFF, which currently is handled in the watch during appending to `db.record` on `watch:elapsed`.
<img width="400" alt="Screenshot 2025-01-31 at 20 13 09" src="https://github.com/user-attachments/assets/0800b2bd-928a-435b-bfa2-a9e8f13549e9" />

NOTE: since now `db.records` contains both Record and Hrv the app needs to handle this in various places. The fit parser and watch cover that. Others may exist, but initial tests with full recording session don't show issues.

closes: #192 