### PR TITLE
Fix the progress indicator for "courses"

### DIFF
--- a/src/views/workout-graph.js
+++ b/src/views/workout-graph.js
@@ -231,13 +231,19 @@ class WorkoutGraph extends HTMLElement {
             $dom.active.style.left   = `${left % width}px`;
             $dom.active.style.width  = `2px`;
             $dom.active.style.height = `${height}px`;
+
+            if(equals(this.type, 'course')) {
+                $dom.progress.style.left   = `${left % width}px`;
+            }
         }
         return;
     }
     onLapTime(lapTime) {
         const self = this;
         this.lapTime = lapTime;
+        if(equals(this.type, 'workout')) {
         this.progress({index: self.index, dom: self.dom, parent: self, lapTime: self.lapTime});
+    }
     }
     progress(args = {}) {
         if(this.workoutStatus === "done") {


### PR DESCRIPTION
When the workout type is "course" we can't rely on lap time for advancing the progress indicator. Using "distance" is more reliable.