### PR TITLE
Low and High Cadence in SteadyState

### DIFF
--- a/src/workouts/zwo.js
+++ b/src/workouts/zwo.js
@@ -472,6 +472,18 @@ function SteadyState(args = {}) {
         const power     = element.Power;
         const powerLow  = element.PowerLow;
         const powerHigh = element.PowerHigh;
+        const cadence     = element.Cadence;
+        const cadenceLow  = element.CadenceLow;
+        const cadenceHigh = element.CadenceHigh;
+
+        if(!exists(cadence) && (exists(cadenceLow) || exists(cadenceHigh))) {
+            const avgCadence = [cadenceLow, cadenceHigh]
+                .filter(exists)
+                .reduce((acc, x, _, { length }) => acc + x / length, 0);
+            element.Cadence = Math.round(avgCadence);
+            element.CadenceLow = undefined;
+            element.CadenceHigh = undefined;
+        }
 
         let step = {};
 


### PR DESCRIPTION
Hi all,
new user here, I use Auuki with intervals.icu and  noticed that  target cadence is not visible while doing my training.

`- 60m 60% 90-100rpm`

Next  I found  that  `CadenceHigh="100" CadenceLow="90"` and  ranges are  not used for displaying the targets. In SteadyState element if power exists as range Auuki  calculates average value for the  target  power. My change  does the same  for the cadence.