### PR TITLE
fix icon colors in light mode

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1667,7 +1667,7 @@
                         x="22.678572"
                         y="31.75" />
                     <g transform="matrix(1.504571,0,0,1.504571,29.141305,37.164828)"
-                        fill="#ffffff">
+                        fill="currentColor">
                         <path
                         d="M 98.569,57.02 77.278,54.093 69.022,17.449 69.01,17.389 C 68.621,15.678 67.296,14.25 65.473,13.817 62.921,13.212 60.361,14.79 59.756,17.342 L 48.048,66.696 37.007,32.288 36.992,32.24 c -0.437,-1.327 -1.514,-2.415 -2.965,-2.803 -2.286,-0.612 -4.636,0.746 -5.247,3.032 L 22.842,54.662 1.464,57.02 c -0.633,0.07 -1.156,0.57 -1.229,1.229 -0.084,0.763 0.466,1.449 1.229,1.534 l 24.618,2.715 c 1.702,0.189 3.342,-0.871 3.825,-2.573 l 0.123,-0.434 3.177,-11.179 11.488,35.134 c 0.433,1.292 1.5,2.371 2.918,2.735 2.224,0.571 4.491,-0.769 5.062,-2.993 l 0.007,-0.026 11.338,-44.156 4.502,20.453 0.132,0.603 c 0.465,2.084 2.459,3.497 4.611,3.201 l 25.302,-3.479 c 0.604,-0.083 1.104,-0.558 1.191,-1.191 0.108,-0.765 -0.426,-1.468 -1.189,-1.573 z"
                         id="path847" />
@@ -1681,29 +1681,29 @@
                 <path d="M320-240h320v-80H320v80Zm0-160h320v-80H320v80ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v480q0 33-23.5 56.5T720-80H240Zm280-520v-200H240v640h480v-440H520ZM240-800v200-200 640-640Z"/>
             </symbol>
             <symbol id="icon--toggle--on" viewBox="0 0 33 20" fill="none">
-                <rect x="1.5" y="1.5" width="30" height="17" rx="8.5" stroke="#FFFFFF" stroke-width="3"/>
-                <circle cx="23" cy="10" r="5" fill="#FFFFFF"/>
+                <rect x="1.5" y="1.5" width="30" height="17" rx="8.5" stroke="currentColor" stroke-width="3"/>
+                <circle cx="23" cy="10" r="5" fill="currentColor"/>
             </symbol>
             <symbol id="icon--toggle--off" viewBox="0 0 33 20" fill="none">
-                <rect x="1.5" y="1.5" width="30" height="17" rx="8.5" stroke="#AAAAAA" stroke-width="3"/>
-                <circle cx="10" cy="10" r="5" fill="#AAAAAA"/>
+                <rect x="1.5" y="1.5" width="30" height="17" rx="8.5" stroke="currentColor" stroke-width="3"/>
+                <circle cx="10" cy="10" r="5" fill="currentColor"/>
             </symbol>
-            <symbol id="icon--sound--mute" viewBox="0 0 24 24" fill="#FFFFFF">
+            <symbol id="icon--sound--mute" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M0 0h24v24H0V0z" fill="none"/>
                 <path d="M7 9v6h4l5 5V4l-5 5H7z"/>
             </symbol>
-            <symbol id="icon--sound--down" viewBox="0 0 24 24" fill="#FFFFFF">
+            <symbol id="icon--sound--down" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M0 0h24v24H0V0z" fill="none"/>
                 <path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/>
             </symbol>
-            <symbol id="icon--sound--up" viewBox="0 0 24 24" fill="#FFFFFF">
+            <symbol id="icon--sound--up" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M0 0h24v24H0V0z" fill="none"/>
                 <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/>
             </symbol>
-            <symbol id="icon--lock--close" height="24px" viewBox="0 -960 960 960" width="24px" fill="#FFFFFF">
+            <symbol id="icon--lock--close" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
                 <path d="M240-80q-33 0-56.5-23.5T160-160v-400q0-33 23.5-56.5T240-640h40v-80q0-83 58.5-141.5T480-920q83 0 141.5 58.5T680-720v80h40q33 0 56.5 23.5T800-560v400q0 33-23.5 56.5T720-80H240Zm0-80h480v-400H240v400Zm240-120q33 0 56.5-23.5T560-360q0-33-23.5-56.5T480-440q-33 0-56.5 23.5T400-360q0 33 23.5 56.5T480-280ZM360-640h240v-80q0-50-35-85t-85-35q-50 0-85 35t-35 85v80ZM240-160v-400 400Z"/>
             </symbol>
-            <symbol id="icon--lock--open" height="24px" viewBox="0 -960 960 960" width="24px" fill="#FFFFFF">
+            <symbol id="icon--lock--open" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
                 <path d="M240-160h480v-400H240v400Zm240-120q33 0 56.5-23.5T560-360q0-33-23.5-56.5T480-440q-33 0-56.5 23.5T400-360q0 33 23.5 56.5T480-280ZM240-160v-400 400Zm0 80q-33 0-56.5-23.5T160-160v-400q0-33 23.5-56.5T240-640h280v-80q0-83 58.5-141.5T720-920q83 0 141.5 58.5T920-720h-80q0-50-35-85t-85-35q-50 0-85 35t-35 85v80h120q33 0 56.5 23.5T800-560v400q0 33-23.5 56.5T720-80H240Z"/>
             </symbol>
         </svg>


### PR DESCRIPTION
Fixes: https://github.com/dvmarinoff/Auuki/issues/296 and few other icons with the same issue.

Before:
<img width="480" height="237" alt="Screenshot 2026-02-26 at 08 52 50" src="https://github.com/user-attachments/assets/f9152b32-01ba-4644-8e0b-2c4de3857577" />
<img width="912" height="804" alt="Screenshot 2026-02-26 at 08 53 04" src="https://github.com/user-attachments/assets/3808eb39-73d7-456f-87e8-93f3d01bcfed" />


------------------

After:
<img width="474" height="322" alt="Screenshot 2026-02-26 at 08 53 19" src="https://github.com/user-attachments/assets/33fd70dd-b203-4f34-bbb1-ce6522df7870" />
<img width="723" height="780" alt="Screenshot 2026-02-26 at 08 53 31" src="https://github.com/user-attachments/assets/29c40571-9a96-4527-88d6-3e7b58d30187" />
